### PR TITLE
fix: fix latest svtav1

### DIFF
--- a/libavcodec/libsvtav1.c
+++ b/libavcodec/libsvtav1.c
@@ -435,7 +435,11 @@ static av_cold int eb_enc_init(AVCodecContext *avctx)
 
     svt_enc->eos_flag = EOS_NOT_REACHED;
 
+#if SVT_AV1_CHECK_VERSION(3, 0, 0)
+    svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, &svt_enc->enc_params);
+#else
     svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
+#endif
     if (svt_ret != EB_ErrorNone) {
         return svt_print_error(avctx, svt_ret, "Error initializing encoder handle");
     }


### PR DESCRIPTION
SVT-AV1 made a change in their public API in 988e930c but without a version bump or any other accessible marker, thus breaking ffmpeg build with current versions of SVT-AV1.

They have finally bumped versions a month later, so check added.

(cherry picked from commit d1ed5c06e3edc5f2b5f3664c80121fa55b0baa95)